### PR TITLE
Update analyze-images.py

### DIFF
--- a/analyze-images.py
+++ b/analyze-images.py
@@ -4,8 +4,8 @@ import os
 import sys
 
 # Import Google Cloud Library modules
-from google.cloud import storage, bigquery, language, vision
-client = vision.ImageAnnotatorClient()
+from google.cloud import storage, bigquery, language, vision_v1
+client = vision_v1.ImageAnnotatorClient()
 
 if ('GOOGLE_APPLICATION_CREDENTIALS' in os.environ):
     if (not os.path.exists(os.environ['GOOGLE_APPLICATION_CREDENTIALS'])):
@@ -29,7 +29,7 @@ bq_client = bigquery.Client(project=project_name)
 nl_client = language.LanguageServiceClient()
 
 # Set up client objects for the vision and translate_v2 API Libraries
-vision_client = vision.ImageAnnotatorClient()
+vision_client = vision_v1.ImageAnnotatorClient()
 
 # Setup the BigQuery dataset and table objects
 dataset_ref = bq_client.dataset('image_classification_dataset')
@@ -52,7 +52,7 @@ for file in files:
         file_content = file.download_as_string()
         
         # TBD: Create a Vision API image object called image_object
-        image_object = vision.types.Image(content=file_content)
+        image_object = vision_v1.types.Image(content=file_content)
         # Ref: https://googleapis.dev/python/vision/latest/gapic/v1/types.html#google.cloud.vision_v1.types.Image
 
 


### PR DESCRIPTION
Change the version of vision from just "**vision**" to "**vision_v1**", otherwise, this causes issues in the lab. I experienced it and went through the documentation and got to know this. The '**types**' are no longer present in the '_vision_' package but '_vision_v1_'.
[Link to Documentation](https://googleapis.dev/python/vision/latest/gapic/v1/types.html#google.cloud.vision_v1.types.AnnotateImageResponse)